### PR TITLE
Fix (de)serialization of components

### DIFF
--- a/src/availability.rs
+++ b/src/availability.rs
@@ -36,7 +36,7 @@ impl Availability {
 }
 
 #[derive(Debug, Serialize, Deserialize, PartialEq, Clone, Copy)]
-#[serde(untagged, rename_all = "snake_case")]
+#[serde(rename_all = "snake_case")]
 pub enum AvailabilityMode {
     All,
     Any,

--- a/src/components/binary_sensor.rs
+++ b/src/components/binary_sensor.rs
@@ -5,7 +5,7 @@ use crate::qos::Qos;
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Clone, PartialEq, Serialize)]
-#[serde(untagged, rename_all = "lowercase")]
+#[serde(rename_all = "lowercase")]
 pub enum BinarySensorState {
     On,
     Off,
@@ -278,7 +278,7 @@ pub enum BinarySensorClass {
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
-#[serde(untagged, rename_all = "snake_case")]
+#[serde(rename_all = "snake_case")]
 pub enum BinarySensorEntityCategory {
     Diagnostic,
 }

--- a/src/components/binary_sensor.rs
+++ b/src/components/binary_sensor.rs
@@ -247,8 +247,6 @@ impl NodeId for BinarySensor<'_> {
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum BinarySensorClass {
-    #[serde(rename = "None")]
-    None,
     Battery,
     BatteryCharging,
     CarbonMonoxide,

--- a/src/components/button.rs
+++ b/src/components/button.rs
@@ -169,8 +169,6 @@ impl<'a> Button<'a> {
 #[derive(Debug, Clone, PartialEq, Serialize)]
 #[serde(rename_all = "snake_case")]
 pub enum ButtonClass {
-    #[serde(rename = "None")]
-    None,
     Identify,
     Restart,
     Update,

--- a/src/components/button.rs
+++ b/src/components/button.rs
@@ -25,6 +25,7 @@ pub struct Button<'a> {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub device: Option<&'a Device>,
 
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub device_class: Option<ButtonClass>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -166,7 +167,7 @@ impl<'a> Button<'a> {
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize)]
-#[serde(untagged, rename_all = "snake_case")]
+#[serde(rename_all = "snake_case")]
 pub enum ButtonClass {
     #[serde(rename = "None")]
     None,
@@ -176,7 +177,7 @@ pub enum ButtonClass {
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize)]
-#[serde(untagged, rename_all = "snake_case")]
+#[serde(rename_all = "snake_case")]
 pub enum ButtonEntityCategory {
     Config,
     Diagnostic,

--- a/src/components/event.rs
+++ b/src/components/event.rs
@@ -64,7 +64,7 @@ pub struct Event<'a> {
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize)]
-#[serde(untagged, rename_all = "snake_case")]
+#[serde(rename_all = "snake_case")]
 pub enum EventClass {
     #[serde(rename = "None")]
     None,
@@ -74,7 +74,7 @@ pub enum EventClass {
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize)]
-#[serde(untagged, rename_all = "snake_case")]
+#[serde(rename_all = "snake_case")]
 pub enum EventEntityCategory {
     Diagnostic,
     Config,

--- a/src/components/event.rs
+++ b/src/components/event.rs
@@ -66,8 +66,6 @@ pub struct Event<'a> {
 #[derive(Debug, Clone, PartialEq, Serialize)]
 #[serde(rename_all = "snake_case")]
 pub enum EventClass {
-    #[serde(rename = "None")]
-    None,
     Button,
     Doorbell,
     Motion,

--- a/src/components/number.rs
+++ b/src/components/number.rs
@@ -232,7 +232,7 @@ impl<'a> Number<'a> {
 }
 
 #[derive(Debug, Serialize, PartialEq, Clone, Copy)]
-#[serde(untagged, rename_all = "snake_case")]
+#[serde(rename_all = "snake_case")]
 pub enum NumberClass {
     #[serde(rename = "None")]
     None,
@@ -287,14 +287,14 @@ pub enum NumberClass {
     WindSpeed,
 }
 #[derive(Debug, Clone, PartialEq, Serialize)]
-#[serde(untagged, rename_all = "snake_case")]
+#[serde(rename_all = "snake_case")]
 pub enum NumberEntityCategory {
     Diagnostic,
     Config,
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize)]
-#[serde(untagged, rename_all = "snake_case")]
+#[serde(rename_all = "snake_case")]
 pub enum NumberMode {
     Auto,
     Box,

--- a/src/components/number.rs
+++ b/src/components/number.rs
@@ -234,8 +234,6 @@ impl<'a> Number<'a> {
 #[derive(Debug, Serialize, PartialEq, Clone, Copy)]
 #[serde(rename_all = "snake_case")]
 pub enum NumberClass {
-    #[serde(rename = "None")]
-    None,
     ApparentPower,
     Aql,
     AtmosphericPressure,

--- a/src/components/sensor.rs
+++ b/src/components/sensor.rs
@@ -223,8 +223,6 @@ pub enum SensorEntityCategory {
 #[derive(Debug, Clone, PartialEq, Serialize)]
 #[serde(rename_all = "snake_case")]
 pub enum SensorClass {
-    #[serde(rename = "None")]
-    None,
     ApparentPower,
     Aql,
     AtmosphericPressure,

--- a/src/components/sensor.rs
+++ b/src/components/sensor.rs
@@ -215,13 +215,13 @@ impl<'a> crate::discoverable::NodeId for Sensor<'a> {
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize)]
-#[serde(untagged, rename_all = "snake_case")]
+#[serde(rename_all = "snake_case")]
 pub enum SensorEntityCategory {
     Diagnostic,
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize)]
-#[serde(untagged, rename_all = "snake_case")]
+#[serde(rename_all = "snake_case")]
 pub enum SensorClass {
     #[serde(rename = "None")]
     None,


### PR DESCRIPTION
This PR aims to fix the serialization and deserialization of components.

The following changes are included:
1) removed `None` case from enums (`None` is a Python keyword indicating that a value is optional, akin to Rust's `Option<_>`)
2) removed `#[serde(untagged]` from enums without associated values
3) add`#[serde(skip_serializing_if = "Option::is_none")]` to `Button::device_class`

(2) fixes wrong serialization of e.g. `Number::mode`, see comparison below.

## Comparison 

Consider the following `Cargo.toml`:
```yaml
[package]
name = "ha-mqtt-test"
version = "0.1.0"
edition = "2021"

[dependencies]
ha_mqtt = { git = "https://github.com/TimLikesTacos/ha_mqtt" }
ha_mqtt_pr = { git = "https://github.com/wassup-/ha_mqtt", package = "ha_mqtt" }
serde_json = "1"
```

and the following `main.rs`:
```rs
fn main() {
    {
        use ha_mqtt::components::number::{Number, NumberMode};

        let number = Number::new("foo".to_owned(), "bar".to_owned()).with_mode(NumberMode::Box);
        println!("{}", serde_json::to_string(&number).unwrap());
    }

    {
        use ha_mqtt_pr::components::number::{Number, NumberMode};

        let number = Number::new("foo".to_owned(), "bar".to_owned()).with_mode(NumberMode::Box);
        println!("{}", serde_json::to_string(&number).unwrap());
    }
}
```

Compare both outputs:
```sh
$ cargo run
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.03s
     Running `target/debug/ha-mqtt-test`
{"command_topic":"foo","mode":null,"unit_of_measurement":"bar"}
{"command_topic":"foo","mode":"box","unit_of_measurement":"bar"}
```